### PR TITLE
Migrate compatible users to Obsidian's `requestUrl` API.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -13,6 +13,7 @@
    80
 ],
 "conventionalCommits.scopes": [
-   "reports"
+   "reports",
+   "api"
 ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.7.2]
+
+### ⚙️ Internal
+
+- When installed on API version 0.13.25 or higher, the plugin now uses Obsidian's own `requestUrl` API instead of the third-party dependency `got`. This lays the foundation for supporting Mobile platforms in the future.
+
 ## [0.7.1] 
 
 ### ✨ Features

--- a/lib/toggl/ApiManager.ts
+++ b/lib/toggl/ApiManager.ts
@@ -8,6 +8,8 @@ import type { ISODate } from 'lib/reports/ReportQuery';
 import { settingsStore } from 'lib/util/stores';
 import moment from 'moment';
 import TogglClient from 'toggl-client';
+import { apiVersion } from 'obsidian';
+import { checkVersion } from 'lib/util/checkVersion';
 
 /** http headers used on every call to the Toggl API. */
 const headers = {
@@ -26,7 +28,11 @@ export default class ApiManager {
 
 	/** Must be called after constructor and before use of the API. */
 	public async initialize(apiToken: string) {
-		this._api = TogglClient({ apiToken, headers });
+		this._api = TogglClient({
+			apiToken,
+			headers,
+			legacy: !checkVersion(apiVersion, 0, 13, 25)
+		});
 		try {
 			await this.testConnection();
 		} catch {

--- a/lib/util/checkVersion.spec.ts
+++ b/lib/util/checkVersion.spec.ts
@@ -1,0 +1,31 @@
+import { checkVersion } from './checkVersion';
+
+describe('parse', () => {
+	it('passes on equal version', () => {
+		expect(checkVersion('1.2.3', 1, 2, 3)).toStrictEqual(true);
+	});
+
+	it('passes on greater patch version', () => {
+		expect(checkVersion('1.2.4', 1, 2, 3)).toStrictEqual(true);
+	});
+
+	it('passes on greater minor version', () => {
+		expect(checkVersion('1.3.4', 1, 2, 3)).toStrictEqual(true);
+	});
+
+	it('passes on greater major version', () => {
+		expect(checkVersion('2.3.4', 1, 2, 3)).toStrictEqual(true);
+	});
+
+	it('fails on lesser major version', () => {
+		expect(checkVersion('0.2.3', 1, 2, 3)).toStrictEqual(false);
+	});
+
+	it('fails on lesser minor version', () => {
+		expect(checkVersion('1.1.3', 1, 2, 3)).toStrictEqual(false);
+	});
+
+	it('fails on lesser patch version', () => {
+		expect(checkVersion('1.2.2', 1, 2, 3)).toStrictEqual(false);
+	});
+});

--- a/lib/util/checkVersion.ts
+++ b/lib/util/checkVersion.ts
@@ -1,0 +1,23 @@
+/**
+ * @param check version string to check. e.g. "0.13.21"
+ * @param major Minimum major version
+ * @param minor Minimum minor version
+ * @param patch Minimum patch version
+ * @return true if input string satisfies the major, minor and patch values (larger or equal than)
+ */
+export function checkVersion(
+	check: string,
+	major: number,
+	minor: number,
+	patch: number
+): boolean {
+	const [checkMajor, checkMinor, checkPatch] = check.split('.');
+	if (
+		parseInt(checkMajor) >= major &&
+		parseInt(checkMinor) >= minor &&
+		parseInt(checkPatch) >= patch
+	) {
+		return true;
+	}
+	return false;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
 				"moment": "^2.29.1",
 				"supports-color": "^9.0.2",
 				"svelte-select": "^4.4.3",
-				"toggl-client": "git://github.com/mcndt/toggl-client.git"
+				"toggl-client": "git://github.com/mcndt/toggl-client.git#obsidian-request-api"
 			},
 			"devDependencies": {
 				"@rollup/plugin-commonjs": "^18.0.0",
@@ -11618,7 +11618,7 @@
 		"toggl-client": {
 			"version": "git+ssh://git@github.com/mcndt/toggl-client.git#0f5a9604aba06e7bb4428248f95b636ef796dae6",
 			"integrity": "sha512-klm9feL8YC+3aoNVFQnvizI1+OsnT/3fsDKo66ueWtSRYY50ZL54Kmezm4c9IAGiqnCvevuMr3zUoGokBZE1Wg==",
-			"from": "toggl-client@git://github.com/mcndt/toggl-client.git",
+			"from": "toggl-client@git://github.com/mcndt/toggl-client.git#obsidian-request-api",
 			"requires": {
 				"debug": "^4.3.1",
 				"got": "^11.8.2"

--- a/package.json
+++ b/package.json
@@ -41,6 +41,6 @@
 		"moment": "^2.29.1",
 		"supports-color": "^9.0.2",
 		"svelte-select": "^4.4.3",
-		"toggl-client": "git://github.com/mcndt/toggl-client.git"
+		"toggl-client": "git://github.com/mcndt/toggl-client.git#obsidian-request-api"
 	}
 }


### PR DESCRIPTION
- Users of version 0.13.25 or higher will use `requestUrl`. These users will enjoy mobile compatibility in a future update.
- Users who cannot update to this version of Obsidian for whatever reason will fall back to the `got` dependency (no mobile support).