### PR TITLE
Feature: Allow reporting on a single date

### DIFF
--- a/lib/reports/parser/parseQueryInterval.spec.ts
+++ b/lib/reports/parser/parseQueryInterval.spec.ts
@@ -83,6 +83,33 @@ describe("parseQueryInterval (relative intervals)", () => {
     );
   });
 
+  test("Single date", () => {
+    const other_test_date = "2023-05-13";
+
+    testParseQueryInterval(
+      {
+        from: other_test_date,
+        input: [other_test_date, "extra_token"],
+        remaining: ["extra_token"],
+        until: other_test_date,
+      },
+      test_date,
+    );
+  });
+
+  test("fails for gibberish date", () => {
+    testParseQueryInterval(
+      {
+        from: null,
+        input: ["gibberish", "extra_token"],
+        remaining: null,
+        until: null,
+      },
+      test_date,
+      /Query must include a time interval expression/,
+    );
+  });
+
   test('"PAST 10 DAYS" includes the last ten days', () => {
     test_date = "2020-01-10";
 

--- a/lib/reports/parser/parseQueryInterval.ts
+++ b/lib/reports/parser/parseQueryInterval.ts
@@ -89,6 +89,15 @@ export class QueryIntervalParser extends Parser {
         }
 
         _tokens.splice(0, 3);
+        break;
+      }
+      default: {
+        const defaultDate = moment(_tokens[pos], ISODateFormat, true);
+        if (defaultDate.isValid()) {
+          _from = defaultDate;
+          _to = _from.clone();
+          _tokens.splice(0, 1);
+        }
       }
     }
 

--- a/lib/ui/views/TogglReportBlock.svelte
+++ b/lib/ui/views/TogglReportBlock.svelte
@@ -14,7 +14,7 @@
   import TogglSummaryReport from "./TogglSummaryReport.svelte";
   import TogglListReport from "./TogglListReport.svelte";
   import LoadingAnimation from "../components/LoadingAnimation.svelte";
-  import { Keyword, Token } from "lib/reports/parser/Parser";
+  import { ISODateFormat, Keyword, Token } from "lib/reports/parser/Parser";
   import { tokenize } from "lib/reports/parser/Tokenize";
   import { getProjectIds } from "lib/stores/projects";
   import { getClientIds } from "lib/stores/clients";
@@ -24,6 +24,7 @@
     EnrichedDetailedReportItem,
     SummaryReportStore,
   } from "lib/toggl/TogglService";
+  import moment from "moment";
 
   export let source: string;
 
@@ -88,6 +89,10 @@
       case Keyword.PAST:
         return `Past ${tokens[2]} ${(<string>tokens[3]).toLowerCase()}`;
       default:
+        const defaultDate = moment(tokens[1], ISODateFormat, true);
+        if (defaultDate.isValid()) {
+          return defaultDate.format("LL");
+        }
         return "Untitled Toggl Report";
     }
   }


### PR DESCRIPTION
## Feature
Updates TQL to support

```toggl
LIST 2023-03-22
```

This currently works as:

```toggl
LIST FROM 2023-03-22 TO 2023-03-22
```

Additionally updated `TogglReportBlock` to properly title a summary with a single date.

Use case: In my Daily Notes I like to add a quick report so I can see what I've been working on during that day.

## Remaining work
Completed
- [x] Update tests
