### PR TITLE
Minor cleanup changes

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,2 @@
-OUTDIR="/Users/maximecannoodt/Documents/obsidian-test-vault/test-vault/.obsidian/plugins/obsidian-toggl-integration"
+OUTDIR="./"
 DEBUG=TRUE

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ coverage/
 
 # obsidian
 data.json
+
+# https://github.com/pjeby/hot-reload
+.hotreload


### PR DESCRIPTION
- Removed hard coded path in `.env`
- Added `.hotreload` to `.gitignore` (https://github.com/pjeby/hot-reload)

NOTE: `.env` should probably not be committed at all; instead, commit a `.env.sample` to use as a template

NOTE: This is a repost of https://github.com/mcndt/obsidian-toggl-integration/pull/120
