### PR TITLE
Add commands to show report, reconnect to Toggl API

### DIFF
--- a/lib/toggl/TogglService.ts
+++ b/lib/toggl/TogglService.ts
@@ -79,6 +79,13 @@ export default class TogglService {
     this._statusBarItem = this._plugin.addStatusBarItem();
     this._statusBarItem = this._plugin.addStatusBarItem();
     this._statusBarItem.setText("Connecting to Toggl...");
+
+    this._plugin.registerDomEvent(
+      this._statusBarItem, "click", () => {
+        new Notice('Reconnecting to Toggl...')
+        this.setToken(this._plugin.settings.apiToken)
+      }
+    )
     // Store a reference to the manager in a svelte store to avoid passing
     // of references around the component trees.
     togglService.set(this);

--- a/main.ts
+++ b/main.ts
@@ -89,6 +89,18 @@ export default class MyPlugin extends Plugin {
       name: "Open report view",
     });
 
+    this.addCommand({
+      checkCallback: (checking: boolean) => {
+        if (!checking) {
+          this.toggl.setToken(this.settings.apiToken);
+        } else {
+          return this.settings.apiToken != null || this.settings.apiToken != "";
+        }
+      },
+      id: "refresh-api",
+      name: "Refresh API Connection",
+    });
+
     // Enable processing codeblocks for rendering in-note reports
     this.registerCodeBlockProcessor();
   }

--- a/main.ts
+++ b/main.ts
@@ -72,6 +72,23 @@ export default class MyPlugin extends Plugin {
       this.app.workspace.onLayoutReady(this.initLeaf.bind(this));
     }
 
+    this.addCommand({
+      callback: async () => {
+        const existing = this.app.workspace.getLeavesOfType(VIEW_TYPE_REPORT);
+        if (existing.length) {
+          this.app.workspace.revealLeaf(existing[0]);
+          return;
+        }
+        await this.app.workspace.getRightLeaf(false).setViewState({
+          active: true,
+          type: VIEW_TYPE_REPORT,
+        });
+        this.app.workspace.revealLeaf(this.app.workspace.getLeavesOfType(VIEW_TYPE_REPORT)[0]);
+      },
+      id: "show-report-view",
+      name: "Open report view",
+    });
+
     // Enable processing codeblocks for rendering in-note reports
     this.registerCodeBlockProcessor();
   }


### PR DESCRIPTION
Adds a new command "Open report view" that opens and focuses the report view leaf.

Following the same structure as https://github.com/liamcain/obsidian-calendar-plugin/pull/275 (thanks for the fix!).
Closes #146
Closes #11