### PR TITLE
Additional status bar format options

### DIFF
--- a/lib/config/DefaultSettings.ts
+++ b/lib/config/DefaultSettings.ts
@@ -4,6 +4,7 @@ export const DEFAULT_SETTINGS: PluginSettings = {
   apiToken: null,
   charLimitStatusBar: 40,
   statusBarFormat: "m [minute]",
+  statusBarPrefix: "Timer: ",
   updateInRealTime: true,
   workspace: { id: "none", name: "None selected" },
 };

--- a/lib/config/DefaultSettings.ts
+++ b/lib/config/DefaultSettings.ts
@@ -5,6 +5,7 @@ export const DEFAULT_SETTINGS: PluginSettings = {
   charLimitStatusBar: 40,
   statusBarFormat: "m [minute]",
   statusBarPrefix: "Timer: ",
+  statusBarShowProject: false,
   updateInRealTime: true,
   workspace: { id: "none", name: "None selected" },
 };

--- a/lib/config/DefaultSettings.ts
+++ b/lib/config/DefaultSettings.ts
@@ -4,6 +4,7 @@ export const DEFAULT_SETTINGS: PluginSettings = {
   apiToken: null,
   charLimitStatusBar: 40,
   statusBarFormat: "m [minute]",
+  statusBarNoEntryMesssage: "-",
   statusBarPrefix: "Timer: ",
   statusBarShowProject: false,
   updateInRealTime: true,

--- a/lib/config/DefaultSettings.ts
+++ b/lib/config/DefaultSettings.ts
@@ -3,6 +3,7 @@ import type { PluginSettings } from "./PluginSettings";
 export const DEFAULT_SETTINGS: PluginSettings = {
   apiToken: null,
   charLimitStatusBar: 40,
+  statusBarFormat: "m [minute]",
   updateInRealTime: true,
   workspace: { id: "none", name: "None selected" },
 };

--- a/lib/config/PluginSettings.ts
+++ b/lib/config/PluginSettings.ts
@@ -11,15 +11,20 @@ export interface PluginSettings {
    */
   workspace: TogglWorkspace;
 
+  /** Has dismissed the update alert for 0.4.0 */
+  hasDismissedAlert?: boolean;
+  
+  /** Update the day's total time in real-time in the sidebar */
+  updateInRealTime?: boolean;
+
   /**
    * The max. allowed characters in the title of a timer in
    * the status bar.
    */
   charLimitStatusBar: number;
 
-  /** Has dismissed the update alert for 0.4.0 */
-  hasDismissedAlert?: boolean;
-
-  /** Update the day's total time in real-time in the sidebar */
-  updateInRealTime?: boolean;
+  /**
+   * The time format for the status bar.
+   */
+  statusBarFormat?: string;
 }

--- a/lib/config/PluginSettings.ts
+++ b/lib/config/PluginSettings.ts
@@ -27,4 +27,9 @@ export interface PluginSettings {
    * The time format for the status bar.
    */
   statusBarFormat?: string;
+
+  /**
+   * The prefix to show before the time entry in the status bar.
+   */
+  statusBarPrefix?: string;
 }

--- a/lib/config/PluginSettings.ts
+++ b/lib/config/PluginSettings.ts
@@ -32,4 +32,7 @@ export interface PluginSettings {
    * The prefix to show before the time entry in the status bar.
    */
   statusBarPrefix?: string;
+
+  /** Whether to show the project in the status bar. */
+  statusBarShowProject?: boolean;
 }

--- a/lib/config/PluginSettings.ts
+++ b/lib/config/PluginSettings.ts
@@ -35,4 +35,7 @@ export interface PluginSettings {
 
   /** Whether to show the project in the status bar. */
   statusBarShowProject?: boolean;
+
+  /** Message shown in the status bar when no time entry is running. */
+  statusBarNoEntryMesssage?: string;
 }

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -4,6 +4,11 @@
 export const ACTIVE_TIMER_POLLING_INTERVAL = 6000;
 
 /**
+ * The interval in ms at which the status bar is updated
+ */
+export const STATUS_BAR_UPDATE_INTERVAL = 1000;
+
+/**
  * The language string used for report code blocks.
  */
 export const CODEBLOCK_LANG = "toggl";

--- a/lib/stores/dailySummary.ts
+++ b/lib/stores/dailySummary.ts
@@ -14,14 +14,14 @@ export const DailySummary = derived(
   [summaryItems, Projects],
   ([$summaryItems, $projects]) => {
     const summary = {
-      projects_breakdown: $summaryItems.map(
+      projects_breakdown: ($summaryItems ?? []).map(
         (item): EnrichedWithProject<typeof item> => ({
           ...item,
           $project:
             $projects.find((project) => project.id === item.project_id) ?? null,
         }),
       ),
-      total_seconds: $summaryItems.reduce((a, b) => a + b.tracked_seconds, 0),
+      total_seconds: ($summaryItems ?? []).reduce((a, b) => a + b.tracked_seconds, 0),
     };
 
     return summary;

--- a/lib/toggl/TogglService.ts
+++ b/lib/toggl/TogglService.ts
@@ -77,7 +77,6 @@ export default class TogglService {
   constructor(plugin: MyPlugin) {
     this._plugin = plugin;
     this._statusBarItem = this._plugin.addStatusBarItem();
-    this._statusBarItem = this._plugin.addStatusBarItem();
     this._statusBarItem.setText("Connecting to Toggl...");
     // Store a reference to the manager in a svelte store to avoid passing
     // of references around the component trees.

--- a/lib/toggl/TogglService.ts
+++ b/lib/toggl/TogglService.ts
@@ -292,7 +292,7 @@ export default class TogglService {
       }
       const duration = this.getTimerDuration(this._currentTimeEntry);
       const time_string = moment.duration(duration, 'seconds').format(
-        'm [minute]',
+        this._plugin.settings.statusBarFormat,
         { trim: false, trunc: true },
       )
       timer_msg = `${title} (${time_string})`;

--- a/lib/toggl/TogglService.ts
+++ b/lib/toggl/TogglService.ts
@@ -30,6 +30,7 @@ import {
 import { apiStatusStore, togglService } from "lib/util/stores";
 import type MyPlugin from "main";
 import moment from "moment";
+import "moment-duration-format";
 import { Notice } from "obsidian";
 import { derived, get } from "svelte/store";
 
@@ -290,8 +291,10 @@ export default class TogglService {
         )}...`;
       }
       const duration = this.getTimerDuration(this._currentTimeEntry);
-      const minutes = Math.floor(duration / 60);
-      const time_string = `${minutes} minute${minutes != 1 ? "s" : ""}`;
+      const time_string = moment.duration(duration, 'seconds').format(
+        'm [minute]',
+        { trim: false, trunc: true },
+      )
       timer_msg = `${title} (${time_string})`;
     }
     this._statusBarItem.setText(`Timer: ${timer_msg}`);

--- a/lib/toggl/TogglService.ts
+++ b/lib/toggl/TogglService.ts
@@ -291,6 +291,7 @@ export default class TogglService {
         )}...`;
       }
       const duration = this.getTimerDuration(this._currentTimeEntry);
+      // @ts-expect-error
       const time_string = moment.duration(duration, 'seconds').format(
         this._plugin.settings.statusBarFormat,
         { trim: false, trunc: true },

--- a/lib/toggl/TogglService.ts
+++ b/lib/toggl/TogglService.ts
@@ -297,7 +297,7 @@ export default class TogglService {
       )
       timer_msg = `${title} (${time_string})`;
     }
-    this._statusBarItem.setText(`Timer: ${timer_msg}`);
+    this._statusBarItem.setText(`${this._plugin.settings.statusBarPrefix}${timer_msg}`);
   }
 
   /**

--- a/lib/toggl/TogglService.ts
+++ b/lib/toggl/TogglService.ts
@@ -1,4 +1,4 @@
-import { ACTIVE_TIMER_POLLING_INTERVAL } from "lib/constants";
+import { ACTIVE_TIMER_POLLING_INTERVAL, STATUS_BAR_UPDATE_INTERVAL } from "lib/constants";
 import type {
   ClientId,
   EnrichedWithClient,
@@ -71,6 +71,7 @@ export default class TogglService {
   private _statusBarItem: HTMLElement;
 
   private _currentTimerInterval: number = null;
+  private _statusBarInterval: number = null;
   private _currentTimeEntry: TimeEntry = null;
   private _ApiAvailable = ApiStatus.UNTESTED;
 
@@ -90,6 +91,7 @@ export default class TogglService {
    */
   public async setToken(token: string) {
     window.clearInterval(this._currentTimerInterval);
+    window.clearInterval(this._statusBarInterval);
     if (token != null && token != "") {
       try {
         this._apiManager = new TogglAPI();
@@ -107,6 +109,7 @@ export default class TogglService {
 
       // Fetch daily summary data and start polling for current timers.
       this.startTimerInterval();
+      this.startStatusBarInterval();
       this._apiManager
         .getDailySummary()
         .then((response) => setDailySummaryItems(response));
@@ -183,6 +186,17 @@ export default class TogglService {
     this._plugin.registerInterval(this._currentTimerInterval);
   }
 
+  /**
+   * Start updating the status bar periodically.
+   */
+  private startStatusBarInterval() {
+    this.updateStatusBarText();
+    this._statusBarInterval = window.setInterval(() => {
+      this.updateStatusBarText();
+    }, STATUS_BAR_UPDATE_INTERVAL);
+    this._plugin.registerInterval(this._statusBarInterval);
+  }
+
   private async updateCurrentTimer() {
     if (!this.isApiAvailable) {
       return;
@@ -256,7 +270,6 @@ export default class TogglService {
     }
 
     this._currentTimeEntry = curr;
-    this.updateStatusBarText();
   }
 
   /**

--- a/lib/toggl/TogglService.ts
+++ b/lib/toggl/TogglService.ts
@@ -295,6 +295,10 @@ export default class TogglService {
         this._plugin.settings.statusBarFormat,
         { trim: false, trunc: true },
       )
+      if (this._plugin.settings.statusBarShowProject){
+        const currentEnhanced = enrichObjectWithProject(this._currentTimeEntry)
+        title += ` - ${currentEnhanced.$project?.name || "No project"}`
+      }
       timer_msg = `${title} (${time_string})`;
     }
     this._statusBarItem.setText(`${this._plugin.settings.statusBarPrefix}${timer_msg}`);

--- a/lib/toggl/TogglService.ts
+++ b/lib/toggl/TogglService.ts
@@ -280,7 +280,7 @@ export default class TogglService {
   private updateStatusBarText() {
     let timer_msg = null;
     if (this._currentTimeEntry == null) {
-      timer_msg = "-";
+      timer_msg = this._plugin.settings.statusBarNoEntryMesssage;
     } else {
       let title: string =
         this._currentTimeEntry.description || "No description";

--- a/lib/toggl/TogglService.ts
+++ b/lib/toggl/TogglService.ts
@@ -291,7 +291,6 @@ export default class TogglService {
         )}...`;
       }
       const duration = this.getTimerDuration(this._currentTimeEntry);
-      // @ts-expect-error
       const time_string = moment.duration(duration, 'seconds').format(
         this._plugin.settings.statusBarFormat,
         { trim: false, trunc: true },

--- a/lib/ui/TogglSettingsTab.ts
+++ b/lib/ui/TogglSettingsTab.ts
@@ -39,6 +39,7 @@ export default class TogglSettingsTab extends PluginSettingTab {
     });
     this.addCharLimitStatusBarSetting(containerEl);
     this.addStatusBarFormatSetting(containerEl);
+    this.addStatusBarPrefixSetting(containerEl);
   }
 
   private addApiTokenSetting(containerEl: HTMLElement) {
@@ -144,6 +145,24 @@ export default class TogglSettingsTab extends PluginSettingTab {
           .setValue(this.plugin.settings.statusBarFormat || "")
           .onChange(async (value) => {
             this.plugin.settings.statusBarFormat = value;
+            await this.plugin.saveSettings();
+          }),
+      );
+  }
+
+  private addStatusBarPrefixSetting(containerEl: HTMLElement) {
+    new Setting(containerEl)
+      .setName("Status bar prefix")
+      .setDesc(
+        "Prefix before the time entry in the status bar. " +
+          "Leave blank for no prefix.",
+      )
+      .addText((text) =>
+        text
+          .setPlaceholder(DEFAULT_SETTINGS.statusBarPrefix)
+          .setValue(this.plugin.settings.statusBarPrefix || "")
+          .onChange(async (value) => {
+            this.plugin.settings.statusBarPrefix = value;
             await this.plugin.saveSettings();
           }),
       );

--- a/lib/ui/TogglSettingsTab.ts
+++ b/lib/ui/TogglSettingsTab.ts
@@ -41,6 +41,7 @@ export default class TogglSettingsTab extends PluginSettingTab {
     this.addStatusBarFormatSetting(containerEl);
     this.addStatusBarPrefixSetting(containerEl);
     this.addStatusBarProjectSetting(containerEl);
+    this.addStatusBarNoEntrySetting(containerEl);
   }
 
   private addApiTokenSetting(containerEl: HTMLElement) {
@@ -183,6 +184,23 @@ export default class TogglSettingsTab extends PluginSettingTab {
             await this.plugin.saveSettings();
           });
       });
+  }
+
+  private addStatusBarNoEntrySetting(containerEl: HTMLElement) {
+    new Setting(containerEl)
+      .setName("No entry status bar message")
+      .setDesc(
+        "Message in the status bar when no time entry is running."
+      )
+      .addText((text) =>
+        text
+          .setPlaceholder(DEFAULT_SETTINGS.statusBarNoEntryMesssage)
+          .setValue(this.plugin.settings.statusBarNoEntryMesssage || "")
+          .onChange(async (value) => {
+            this.plugin.settings.statusBarNoEntryMesssage = value;
+            await this.plugin.saveSettings();
+          }),
+      );
   }
 
   private async fetchWorkspaces() {

--- a/lib/ui/TogglSettingsTab.ts
+++ b/lib/ui/TogglSettingsTab.ts
@@ -40,6 +40,7 @@ export default class TogglSettingsTab extends PluginSettingTab {
     this.addCharLimitStatusBarSetting(containerEl);
     this.addStatusBarFormatSetting(containerEl);
     this.addStatusBarPrefixSetting(containerEl);
+    this.addStatusBarProjectSetting(containerEl);
   }
 
   private addApiTokenSetting(containerEl: HTMLElement) {
@@ -166,6 +167,22 @@ export default class TogglSettingsTab extends PluginSettingTab {
             await this.plugin.saveSettings();
           }),
       );
+  }
+
+  private addStatusBarProjectSetting(containerEl: HTMLElement) {
+    new Setting(containerEl)
+      .setName("Show project in status bar")
+      .setDesc(
+        "Show the project of the time entry displayed in the status bar."
+      )
+      .addToggle((toggle) => {
+        toggle
+          .setValue(this.plugin.settings.statusBarShowProject || false)
+          .onChange(async (value) => {
+            this.plugin.settings.statusBarShowProject = value;
+            await this.plugin.saveSettings();
+          });
+      });
   }
 
   private async fetchWorkspaces() {

--- a/lib/ui/TogglSettingsTab.ts
+++ b/lib/ui/TogglSettingsTab.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_SETTINGS } from "lib/config/DefaultSettings";
 import type MyPlugin from "main";
 import {
   App,
@@ -32,6 +33,7 @@ export default class TogglSettingsTab extends PluginSettingTab {
     this.addTestConnectionSetting(containerEl);
     this.addWorkspaceSetting(containerEl);
     this.addUpdateRealTimeSetting(containerEl);
+    this.addCharLimitStatusBarSetting(containerEl);
   }
 
   private addApiTokenSetting(containerEl: HTMLElement) {
@@ -102,6 +104,26 @@ export default class TogglSettingsTab extends PluginSettingTab {
             await this.plugin.saveSettings();
           });
       });
+  }
+
+  private addCharLimitStatusBarSetting(containerEl: HTMLElement) {
+    new Setting(containerEl)
+      .setName("Status bar character limit")
+      .setDesc(
+        "Set a character limit for the time entry " + 
+        "displayed in the status bar."
+      )
+      .addText((text) => {
+        text.setPlaceholder(String(DEFAULT_SETTINGS.charLimitStatusBar))
+        text.inputEl.type = "number"
+        text.setValue(String(this.plugin.settings.charLimitStatusBar))
+        text.onChange(async (value) => {
+          this.plugin.settings.charLimitStatusBar = (
+            value !== "" ? Number(value) : DEFAULT_SETTINGS.charLimitStatusBar
+          );
+          await this.plugin.saveSettings();
+        });
+    });
   }
 
   private async fetchWorkspaces() {

--- a/lib/ui/TogglSettingsTab.ts
+++ b/lib/ui/TogglSettingsTab.ts
@@ -33,7 +33,12 @@ export default class TogglSettingsTab extends PluginSettingTab {
     this.addTestConnectionSetting(containerEl);
     this.addWorkspaceSetting(containerEl);
     this.addUpdateRealTimeSetting(containerEl);
+
+    containerEl.createEl("h2", {
+      text: "Status bar display options",
+    });
     this.addCharLimitStatusBarSetting(containerEl);
+    this.addStatusBarFormatSetting(containerEl);
   }
 
   private addApiTokenSetting(containerEl: HTMLElement) {
@@ -124,6 +129,24 @@ export default class TogglSettingsTab extends PluginSettingTab {
           await this.plugin.saveSettings();
         });
     });
+  }
+
+  private addStatusBarFormatSetting(containerEl: HTMLElement) {
+    new Setting(containerEl)
+      .setName("Status bar time format")
+      .setDesc(
+        "Time format for the status bar. " +
+          "See https://github.com/jsmreese/moment-duration-format for format options.",
+      )
+      .addText((text) =>
+        text
+          .setPlaceholder(DEFAULT_SETTINGS.statusBarFormat)
+          .setValue(this.plugin.settings.statusBarFormat || "")
+          .onChange(async (value) => {
+            this.plugin.settings.statusBarFormat = value;
+            await this.plugin.saveSettings();
+          }),
+      );
   }
 
   private async fetchWorkspaces() {

--- a/lib/ui/components/current_timer/CurrentTimerDisplay.svelte
+++ b/lib/ui/components/current_timer/CurrentTimerDisplay.svelte
@@ -33,7 +33,7 @@
         <span
           class="timer-project-name"
           style:color={timer.$project?.color ?? "var(--text-muted)"}
-          >{timer.$project.name}</span
+          >{timer.$project?.name ?? "No project"}</span
         >
         <span class="divider-bullet mx-1">•</span>
         <span class="timer-duration">{secondsToTimeString(duration)}</span>

--- a/lib/util/millisecondsToTimeString.ts
+++ b/lib/util/millisecondsToTimeString.ts
@@ -1,15 +1,16 @@
-export default function millisecondsToTimeString(ms: number): string {
-  const sec = Math.round((ms / 1000) % 60);
-  const min = Math.floor((ms / 1000 / 60) % 60);
-  const hr = Math.floor(ms / 1000 / 60 / 60);
+import moment from "moment";
+import "moment-duration-format";
 
-  return `${hr}:${min < 10 ? "0" + min : min}:${sec < 10 ? "0" + sec : sec}`;
+export default function millisecondsToTimeString(ms: number): string {
+  return moment.duration(ms).format(
+    'h:mm:ss',
+    { trim: false, trunc: true },
+  )
 }
 
 export function secondsToTimeString(seconds: number): string {
-  const sec = Math.round(seconds % 60);
-  const min = Math.floor((seconds / 60) % 60);
-  const hr = Math.floor(seconds / 60 / 60);
-
-  return `${hr}:${min < 10 ? "0" + min : min}:${sec < 10 ? "0" + sec : sec}`;
+  return moment.duration(seconds, 'seconds').format(
+    'h:mm:ss',
+    { trim: false, trunc: true },
+  )
 }

--- a/lib/util/millisecondsToTimeString.ts
+++ b/lib/util/millisecondsToTimeString.ts
@@ -2,6 +2,7 @@ import moment from "moment";
 import "moment-duration-format";
 
 export default function millisecondsToTimeString(ms: number): string {
+  // @ts-expect-error
   return moment.duration(ms).format(
     'h:mm:ss',
     { trim: false, trunc: true },
@@ -9,6 +10,7 @@ export default function millisecondsToTimeString(ms: number): string {
 }
 
 export function secondsToTimeString(seconds: number): string {
+  // @ts-expect-error
   return moment.duration(seconds, 'seconds').format(
     'h:mm:ss',
     { trim: false, trunc: true },

--- a/lib/util/millisecondsToTimeString.ts
+++ b/lib/util/millisecondsToTimeString.ts
@@ -2,7 +2,6 @@ import moment from "moment";
 import "moment-duration-format";
 
 export default function millisecondsToTimeString(ms: number): string {
-  // @ts-expect-error
   return moment.duration(ms).format(
     'h:mm:ss',
     { trim: false, trunc: true },
@@ -10,7 +9,6 @@ export default function millisecondsToTimeString(ms: number): string {
 }
 
 export function secondsToTimeString(seconds: number): string {
-  // @ts-expect-error
   return moment.duration(seconds, 'seconds').format(
     'h:mm:ss',
     { trim: false, trunc: true },

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "d3": "^7.2.1",
         "moment": "^2.29.4",
+        "moment-duration-format": "^2.3.2",
         "supports-color": "^9.2.2",
         "svelte-select": "^4.4.3",
         "toggl-client": "github:mcndt/toggl-client#b8d88805fb"
@@ -5504,6 +5505,11 @@
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/moment-duration-format": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/moment-duration-format/-/moment-duration-format-2.3.2.tgz",
+      "integrity": "sha512-cBMXjSW+fjOb4tyaVHuaVE/A5TqkukDWiOfxxAjY+PEqmmBQlLwn+8OzwPiG3brouXKY5Un4pBjAeB6UToXHaQ=="
     },
     "node_modules/mri": {
       "version": "1.2.0",
@@ -11484,6 +11490,11 @@
       "version": "2.29.4",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
       "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w=="
+    },
+    "moment-duration-format": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/moment-duration-format/-/moment-duration-format-2.3.2.tgz",
+      "integrity": "sha512-cBMXjSW+fjOb4tyaVHuaVE/A5TqkukDWiOfxxAjY+PEqmmBQlLwn+8OzwPiG3brouXKY5Un4pBjAeB6UToXHaQ=="
     },
     "mri": {
       "version": "1.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
       "devDependencies": {
         "@tsconfig/svelte": "^2.0.1",
         "@types/d3": "^7.1.0",
+        "@types/moment-duration-format": "^2.2.6",
         "@types/node": "^14.17.18",
         "@typescript-eslint/eslint-plugin": "^5.2.0",
         "@typescript-eslint/parser": "^5.2.0",
@@ -1666,6 +1667,15 @@
       "integrity": "sha512-FXCJgyyN3ivVgRoml4h94G/p3kY+u/B86La+QptcqJaWtBWtmc6TtkNfS40n9bIvyLteHh7zXOtgbobORKPbDg==",
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@types/moment-duration-format": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/@types/moment-duration-format/-/moment-duration-format-2.2.6.tgz",
+      "integrity": "sha512-Qw+6ys3sQCatqukjoIBsL1UJq6S7ep4ixrNvDkdViSgzw2ZG3neArXNu3ww7mEG8kwP32ZDoON/esWb7OUckRQ==",
+      "dev": true,
+      "dependencies": {
+        "moment": ">=2.14.0"
       }
     },
     "node_modules/@types/node": {
@@ -8769,6 +8779,15 @@
       "integrity": "sha512-FXCJgyyN3ivVgRoml4h94G/p3kY+u/B86La+QptcqJaWtBWtmc6TtkNfS40n9bIvyLteHh7zXOtgbobORKPbDg==",
       "requires": {
         "@types/node": "*"
+      }
+    },
+    "@types/moment-duration-format": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/@types/moment-duration-format/-/moment-duration-format-2.2.6.tgz",
+      "integrity": "sha512-Qw+6ys3sQCatqukjoIBsL1UJq6S7ep4ixrNvDkdViSgzw2ZG3neArXNu3ww7mEG8kwP32ZDoON/esWb7OUckRQ==",
+      "dev": true,
+      "requires": {
+        "moment": ">=2.14.0"
       }
     },
     "@types/node": {

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
   "dependencies": {
     "d3": "^7.2.1",
     "moment": "^2.29.4",
+    "moment-duration-format": "^2.3.2",
     "supports-color": "^9.2.2",
     "svelte-select": "^4.4.3",
     "toggl-client": "github:mcndt/toggl-client#b8d88805fb"

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "devDependencies": {
     "@tsconfig/svelte": "^2.0.1",
     "@types/d3": "^7.1.0",
+    "@types/moment-duration-format": "^2.2.6",
     "@types/node": "^14.17.18",
     "@typescript-eslint/eslint-plugin": "^5.2.0",
     "@typescript-eslint/parser": "^5.2.0",


### PR DESCRIPTION
An easy improvement, since the setting already exists. Code for handing numbers very similar to https://github.com/liamcain/obsidian-calendar-plugin/blob/master/src/settings.ts#L108-L122

Also removes a duplicate initiation of a status bar item (which has been creating additional spacing in the status bar)

Edit: also closes #151