### PR TITLE
feat: add custom API base URL setting

### DIFF
--- a/lib/config/DefaultSettings.ts
+++ b/lib/config/DefaultSettings.ts
@@ -2,6 +2,7 @@ import type { PluginSettings } from "./PluginSettings";
 
 export const DEFAULT_SETTINGS: PluginSettings = {
   apiToken: null,
+  apiBaseUrl: "https://api.track.toggl.com",
   charLimitStatusBar: 40,
   statusBarFormat: "m [minute]",
   statusBarNoEntryMesssage: "-",

--- a/lib/config/PluginSettings.ts
+++ b/lib/config/PluginSettings.ts
@@ -7,6 +7,13 @@ export interface PluginSettings {
   apiToken: string;
 
   /**
+   * The base URL of the Toggl API. Useful for self-hosted proxies
+   * or alternative endpoints. The path `/api/v9` is appended
+   * automatically. Defaults to `https://api.track.toggl.com`.
+   */
+  apiBaseUrl?: string;
+
+  /**
    * The Toggl workspace to be used for the user's timer.
    */
   workspace: TogglWorkspace;

--- a/lib/toggl/ApiManager.ts
+++ b/lib/toggl/ApiManager.ts
@@ -48,8 +48,9 @@ export default class TogglAPI {
     this._api = createClient(apiToken, this._settings?.apiBaseUrl);
     try {
       await this.testConnection();
-    } catch {
-      throw "Cannot connect to Toggl API.";
+    } catch (err) {
+      console.error("[toggl] testConnection failed:", err);
+      throw err instanceof Error ? err : new Error(String(err));
     }
   }
 

--- a/lib/toggl/ApiManager.ts
+++ b/lib/toggl/ApiManager.ts
@@ -45,7 +45,7 @@ export default class TogglAPI {
    * Must be called after constructor and before use of the API.
    */
   public async setToken(apiToken: string) {
-    this._api = createClient(apiToken);
+    this._api = createClient(apiToken, this._settings?.apiBaseUrl);
     try {
       await this.testConnection();
     } catch {

--- a/lib/toggl/TogglClient.ts
+++ b/lib/toggl/TogglClient.ts
@@ -13,10 +13,24 @@ const headers = {
  * @param apiToken the Toggl API token to use for the client.
  * @returns a TogglClient instance.
  */
-export function createClient(apiToken: string): typeof import("toggl-client") {
-  return TogglClient({
+export function createClient(
+  apiToken: string,
+  apiBaseUrl?: string,
+): typeof import("toggl-client") {
+  const client = TogglClient({
     apiToken,
     headers,
     legacy: checkVersion(apiVersion, 0, 13, 25),
   });
+
+  // `toggl-client` hardcodes the API base URL. If the user has provided
+  // a custom base, override the underlying `got` instance's prefixUrl.
+  if (apiBaseUrl && apiBaseUrl.trim() !== "") {
+    const trimmed = apiBaseUrl.trim().replace(/\/+$/, "");
+    client.httpClient = client.httpClient.extend({
+      prefixUrl: `${trimmed}/api/v9`,
+    });
+  }
+
+  return client;
 }

--- a/lib/toggl/TogglClient.ts
+++ b/lib/toggl/TogglClient.ts
@@ -23,13 +23,36 @@ export function createClient(
     legacy: checkVersion(apiVersion, 0, 13, 25),
   });
 
-  // `toggl-client` hardcodes the API base URL. If the user has provided
-  // a custom base, override the underlying `got` instance's prefixUrl.
+  // `toggl-client` hardcodes the API base URL in two places:
+  //   - `client.httpClient` default prefixUrl (Track API v9)
+  //   - per-request `prefixUrl` overrides inside reports.js (Reports API v2/v3)
+  // If the user has provided a custom base, rewrite both so every call
+  // (Track API *and* Reports API) is routed through the custom endpoint.
   if (apiBaseUrl && apiBaseUrl.trim() !== "") {
     const trimmed = apiBaseUrl.trim().replace(/\/+$/, "");
+    const OFFICIAL = "https://api.track.toggl.com";
+
+    // 1) Track API v9 — replace the default prefixUrl on the shared got instance.
     client.httpClient = client.httpClient.extend({
       prefixUrl: `${trimmed}/api/v9`,
     });
+
+    // 2) Reports API — wrap `client.request` so any per-call prefixUrl pointing
+    //    at the official host gets rewritten to the user's base.
+    const originalRequest = client.request.bind(client);
+    client.request = async function (path: string, options: any) {
+      if (
+        options &&
+        typeof options.prefixUrl === "string" &&
+        options.prefixUrl.startsWith(OFFICIAL)
+      ) {
+        options = {
+          ...options,
+          prefixUrl: trimmed + options.prefixUrl.slice(OFFICIAL.length),
+        };
+      }
+      return originalRequest(path, options);
+    };
   }
 
   return client;

--- a/lib/toggl/TogglClient.ts
+++ b/lib/toggl/TogglClient.ts
@@ -23,22 +23,32 @@ export function createClient(
     legacy: checkVersion(apiVersion, 0, 13, 25),
   });
 
-  // `toggl-client` hardcodes the API base URL in two places:
-  //   - `client.httpClient` default prefixUrl (Track API v9)
-  //   - per-request `prefixUrl` overrides inside reports.js (Reports API v2/v3)
-  // If the user has provided a custom base, rewrite both so every call
+  // The mcndt fork of `toggl-client` (used by this plugin) hardcodes the
+  // API base URL in two places:
+  //   - `client.gotOptions.prefixUrl` for Track API v9 (read on every
+  //     `requestObsidian` / legacy `requestGot` call)
+  //   - per-request `prefixUrl` options injected by reports.js for the
+  //     Reports API v2/v3
+  // If the user configured a custom base, rewrite both so every call
   // (Track API *and* Reports API) is routed through the custom endpoint.
   if (apiBaseUrl && apiBaseUrl.trim() !== "") {
     const trimmed = apiBaseUrl.trim().replace(/\/+$/, "");
     const OFFICIAL = "https://api.track.toggl.com";
 
-    // 1) Track API v9 — replace the default prefixUrl on the shared got instance.
-    client.httpClient = client.httpClient.extend({
-      prefixUrl: `${trimmed}/api/v9`,
-    });
+    // 1) Track API v9 — overwrite the default prefixUrl. In legacy mode the
+    //    already-built `httpClient` must also be refreshed since it captured
+    //    the old prefixUrl at construction time.
+    if (client.gotOptions) {
+      client.gotOptions.prefixUrl = `${trimmed}/api/v9`;
+    }
+    if (client.httpClient && typeof client.httpClient.extend === "function") {
+      client.httpClient = client.httpClient.extend({
+        prefixUrl: `${trimmed}/api/v9`,
+      });
+    }
 
-    // 2) Reports API — wrap `client.request` so any per-call prefixUrl pointing
-    //    at the official host gets rewritten to the user's base.
+    // 2) Reports API — wrap `client.request` so any per-call prefixUrl
+    //    pointing at the official host gets rewritten to the user's base.
     const originalRequest = client.request.bind(client);
     client.request = async function (path: string, options: any) {
       if (

--- a/lib/toggl/TogglService.ts
+++ b/lib/toggl/TogglService.ts
@@ -113,8 +113,8 @@ export default class TogglService {
         this._apiManager = new TogglAPI();
         await this._apiManager.setToken(token);
         this._setApiStatus(ApiStatus.AVAILABLE);
-      } catch {
-        console.error("Cannot connect to toggl API.");
+      } catch (err) {
+        console.error("Cannot connect to toggl API.", err);
         this._statusBarItem.setText("Cannot connect to Toggl API");
         this._setApiStatus(ApiStatus.UNREACHABLE);
         this.noticeAPINotAvailable();

--- a/lib/ui/TogglSettingsTab.ts
+++ b/lib/ui/TogglSettingsTab.ts
@@ -30,6 +30,7 @@ export default class TogglSettingsTab extends PluginSettingTab {
     });
 
     this.addApiTokenSetting(containerEl);
+    this.addApiBaseUrlSetting(containerEl);
     this.addTestConnectionSetting(containerEl);
     this.addWorkspaceSetting(containerEl);
     this.addUpdateRealTimeSetting(containerEl);
@@ -59,6 +60,29 @@ export default class TogglSettingsTab extends PluginSettingTab {
             this.plugin.settings.apiToken = value;
             this.plugin.toggl.refreshApiConnection(value);
             await this.plugin.saveSettings();
+          }),
+      );
+  }
+
+  private addApiBaseUrlSetting(containerEl: HTMLElement) {
+    new Setting(containerEl)
+      .setName("API Base URL")
+      .setDesc(
+        "Base URL for the Toggl API. Change this only if you use a " +
+          "self-hosted proxy or alternative endpoint. The path " +
+          "`/api/v9` is appended automatically.",
+      )
+      .addText((text) =>
+        text
+          .setPlaceholder(DEFAULT_SETTINGS.apiBaseUrl)
+          .setValue(this.plugin.settings.apiBaseUrl || "")
+          .onChange(async (value) => {
+            this.plugin.settings.apiBaseUrl =
+              value.trim() !== "" ? value.trim() : DEFAULT_SETTINGS.apiBaseUrl;
+            await this.plugin.saveSettings();
+            this.plugin.toggl.refreshApiConnection(
+              this.plugin.settings.apiToken,
+            );
           }),
       );
   }

--- a/lib/ui/TogglSettingsTab.ts
+++ b/lib/ui/TogglSettingsTab.ts
@@ -5,6 +5,7 @@ import {
   ButtonComponent,
   DropdownComponent,
   ExtraButtonComponent,
+  Notice,
   PluginSettingTab,
   Setting,
 } from "obsidian";
@@ -259,8 +260,12 @@ export default class TogglSettingsTab extends PluginSettingTab {
     try {
       await this.plugin.toggl.testConnection();
       button.setButtonText("success!");
-    } catch {
+    } catch (err) {
       button.setButtonText("test failed");
+      const message =
+        err instanceof Error ? err.message : String(err ?? "unknown error");
+      console.error("[toggl] test connection failed:", err);
+      new Notice(`Toggl connection failed: ${message}`, 10000);
     } finally {
       button.setDisabled(false);
       window.setTimeout(() => {


### PR DESCRIPTION
## Summary

- Adds an optional **API Base URL** field in plugin settings (default `https://api.track.toggl.com`), so the plugin can point to Toggl-API-compatible backends such as self-hosted [OpenToggl](https://github.com/CorrectRoadH/opentoggl) instead of the hardcoded `api.track.toggl.com`.
- The path `/api/v9` is appended automatically; trailing slashes on the user-supplied value are stripped. Leaving the field blank falls back to the default — existing Toggl Cloud users are unaffected.
- Implementation: `createClient()` now takes an optional `apiBaseUrl` and, when provided, overrides `toggl-client`'s underlying `got` instance via `httpClient.extend({ prefixUrl })`. Because all Track v9 and Reports v3 calls share the same `httpClient`, both APIs are routed through the custom base.

Closes #187
